### PR TITLE
Exporter logs into /var/log and other fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Prometheus Metrics Exporters packaged for use with Apptuit.ai.
 * [Memcached Metrics Exporter](memcached_exporter)
 * [MySQL Server Metrics Exporter](mysqld_exporter)
 * [Elasticsearch Metrics Exporter](elasticsearch_exporter)
+* [Cassandra Metrics Exporter](cassandra_exporter)
+* [Redis Metrics Exporter](redis_exporter)

--- a/cassandra_exporter/README.md
+++ b/cassandra_exporter/README.md
@@ -1,4 +1,4 @@
-# Cassandra Metrics Exporter [![Build Status](https://travis-ci.org/ApptuitAI/prometheus-exporters.svg?branch=master)](https://travis-ci.org/ApptuitAI/prometheus-exporters)
+# Cassandra Metrics Exporter [![Build Status](https://travis-ci.com/ApptuitAI/prometheus-exporters.svg?branch=master)](https://travis-ci.com/ApptuitAI/prometheus-exporters)
 
 Prometheus Cassandra metrics exporter for reporting metrics to Apptuit.ai
 

--- a/cassandra_exporter/assets/opt/prometheus/cassandra_exporter/bin/cassandra_exporter
+++ b/cassandra_exporter/assets/opt/prometheus/cassandra_exporter/bin/cassandra_exporter
@@ -1,6 +1,7 @@
 #!/bin/bash
 
+echo "$(date)"
 echo "Starting Cassandra Exporter..."
 
-/usr/bin/nohup /usr/bin/java -jar /opt/prometheus/jmx_exporter_base/lib/jmx_prometheus_httpserver-0.11.0-jar-with-dependencies.jar localhost:9500 \
+/usr/bin/java -jar /opt/prometheus/jmx_exporter_base/lib/jmx_prometheus_httpserver-0.11.0-jar-with-dependencies.jar localhost:9500 \
 		/opt/prometheus/cassandra_exporter/conf/cassandra.yml

--- a/common/assets/usr/lib/systemd/system/template-exporter.service
+++ b/common/assets/usr/lib/systemd/system/template-exporter.service
@@ -16,8 +16,9 @@ WantedBy=multi-user.target
 PermissionsStartOnly=true
 User=prometheus
 Group=prometheus
-
+PIDFile=/var/run/prometheus/@SRC_PACKAGE_NAME@/@SRC_PACKAGE_NAME@.pid
 Type=simple
+KillMode=control-group
 
 WorkingDirectory=/opt/prometheus/@SRC_PACKAGE_NAME@/
 

--- a/common/common.sh
+++ b/common/common.sh
@@ -79,17 +79,6 @@ function print_message () {
 
 }
 
-function update_config () {
-    print_message "Updating access token in: /etc/xcollector/xcollector.yml\n"
-    $sudo_cmd sh -c "sed -e 's/access_token:.*/access_token: $xc_access_token/' -i /etc/xcollector/xcollector.yml"
-
-    if [ -n "$xc_global_tags" ]; then
-        print_message "Updating tags in: /etc/xcollector/xcollector.yml\n"
-        $sudo_cmd sh -c "/usr/local/xcollector/xcollector.py --set-option-tags $xc_global_tags"
-    fi
-
-}
-
 function post_complete () {
     print_message "success" "Installation of $1 completed successfully\n"
 }

--- a/common/deb/assets/etc/init.d/template-exporter
+++ b/common/deb/assets/etc/init.d/template-exporter
@@ -26,6 +26,7 @@ fi
 . /lib/lsb/init-functions
 
 PIDFILE=${PIDFILE-"/var/run/prometheus/@SRC_PACKAGE_NAME@/@SRC_PACKAGE_NAME@.pid"}
+LOGFILE=${LOGFILE-"/var/log/prometheus/@SRC_PACKAGE_NAME@/@SRC_PACKAGE_NAME@.log"}
 
 RUN_AS_USER=${RUN_AS_USER-prometheus}
 RUN_AS_GROUP=${RUN_AS_GROUP-prometheus}
@@ -44,10 +45,18 @@ case $1 in
         log_daemon_msg "Starting @DEB_PACKAGE_NAME@"
         sanity_check || return $?
 
-        start-stop-daemon --start --quiet -u $RUN_AS_USER \
-            --pidfile "$PIDFILE" --chuid $RUN_AS_USER:$RUN_AS_GROUP \
-            --background --make-pidfile --startas $EXPORTER_BINARY -- \
-            $EXPORTER_FLAGS
+		if [ ! -z "$IN_CONTAINER" ]
+		then
+			start-stop-daemon --start --quiet --no-close -u $RUN_AS_USER \
+				--pidfile "$PIDFILE" --chuid $RUN_AS_USER:$RUN_AS_GROUP \
+				--background --make-pidfile --startas $EXPORTER_BINARY -- \
+				$EXPORTER_FLAGS
+		else
+			start-stop-daemon --start --quiet --no-close -u $RUN_AS_USER \
+				--pidfile "$PIDFILE" --chuid $RUN_AS_USER:$RUN_AS_GROUP \
+				--background --make-pidfile --startas $EXPORTER_BINARY -- \
+				$EXPORTER_FLAGS >> $LOGFILE 2>&1
+        fi
 
         log_end_msg $?
         ;;
@@ -57,7 +66,14 @@ case $1 in
             log_failure_msg "$PIDFILE doesn't exist. @DEB_PACKAGE_NAME@ not running?"
             exit 0
         fi
-        start-stop-daemon --stop --retry 30 --quiet --oknodo -u $RUN_AS_USER --pidfile "$PIDFILE" && rm -f "$PIDFILE"
+        pid=$(cat $PIDFILE)
+        cpid=$(pgrep -P $pid)
+        if [ $? -eq 0 ]
+        then
+        	sudo -u $RUN_AS_USER kill -9 $pid $cpid && rm -f "$PIDFILE"
+        else
+        	start-stop-daemon --stop --retry 30 --quiet --oknodo -u $RUN_AS_USER --pidfile "$PIDFILE" && rm -f "$PIDFILE"
+        fi
         rv=$?
         log_end_msg 0
         exit $rv

--- a/common/rpm/assets/etc/init.d/template-exporter
+++ b/common/rpm/assets/etc/init.d/template-exporter
@@ -50,7 +50,7 @@ start() {
   sanity_check || return $?
   su - ${RUN_AS_USER} -s /bin/bash -c "@EXPORTER_ENVIRONMENT_VARIABLES@ EXPORTER_FLAGS=\"$EXPORTER_FLAGS\" nohup $EXPORTER_BINARY $EXPORTER_FLAGS >> $LOGFILE 2>&1 &"
   sleep 1
-  echo $(pidof @SRC_PACKAGE_NAME@) > ${PIDFILE}
+  echo $(pidof -xs @SRC_PACKAGE_NAME@) > ${PIDFILE}
   read PID < "${PIDFILE}"
   RETVAL=$?
   echo "Running as PID ${PID}"
@@ -63,7 +63,14 @@ start() {
 stop() {
   echo -n $"Stopping $prog: "
   sanity_check || return $?
-  killproc -p $PIDFILE -d 15 $EXPORTER_BINARY
+  pid=$(cat $PIDFILE)
+  cpid=$(pgrep -P $pid)
+  if [ $? -eq 0 ]
+  then
+    sudo -u $RUN_AS_USER kill -9 $pid $cpid && rm -f "$PIDFILE"
+  else
+    killproc -p $PIDFILE -d 15 $EXPORTER_BINARY
+  fi
   RETVAL=$?
   echo
   return $RETVAL

--- a/elasticsearch_exporter/README.md
+++ b/elasticsearch_exporter/README.md
@@ -1,4 +1,4 @@
-# Elasticsearch Metrics Exporter [![Build Status](https://www.travis-ci.org/ApptuitAI/prometheus-exporters.svg?branch=master)](https://www.travis-ci.org/ApptuitAI/prometheus-exporters)
+# Elasticsearch Metrics Exporter [![Build Status](https://travis-ci.com/ApptuitAI/prometheus-exporters.svg?branch=master)](https://travis-ci.com/ApptuitAI/prometheus-exporters)
 
 Prometheus Elasticsearch metrics exporter for reporting metrics to Apptuit.ai
 

--- a/memcached_exporter/README.md
+++ b/memcached_exporter/README.md
@@ -1,4 +1,4 @@
-# Memcache Metrics Exporter [![Build Status](https://www.travis-ci.org/ApptuitAI/prometheus-exporters.svg?branch=master)](https://www.travis-ci.org/ApptuitAI/prometheus-exporters)
+# Memcache Metrics Exporter [![Build Status](https://travis-ci.com/ApptuitAI/prometheus-exporters.svg?branch=master)](https://travis-ci.com/ApptuitAI/prometheus-exporters)
 
 Prometheus exporter for Memcache metrics for reporting metrics to Apptuit.ai
 

--- a/memcached_exporter/install.sh
+++ b/memcached_exporter/install.sh
@@ -41,7 +41,7 @@ function configure_exporter_noninteractively() {
 	if [ -z "$MEMCACHE_ADDRESS" ];
 	then
 		MEMCACHE_ADDRESS=${DEFAULT_MEMCACHE_ADDRESS}
-		print_message "warn" "Env variable MEMCACHE_ADDRESS not found. Using Default address ($MEMCACHE_ADDRESS}) for accessing memcache instance. Please edit /etc/default/memcached-exporter if you would like to change it later.\n"
+		print_message "warn" "Env variable MEMCACHE_ADDRESS not found. Using Default address ($MEMCACHE_ADDRESS) for accessing memcache instance. Please edit /etc/default/memcached-exporter if you would like to change it later.\n"
 	else
 		print_message "info" "Using MEMCACHE_ADDRESS=$MEMCACHE_ADDRESS to configure exporter.\n"
 		update_exporter_configuration $MEMCACHE_ADDRESS

--- a/mysqld_exporter/README.md
+++ b/mysqld_exporter/README.md
@@ -1,4 +1,4 @@
-# MySQL Server Metrics Exporter [![Build Status](https://travis-ci.com/ApptuitAI/prometheus-exporters.svg?branch=master)](https://www.travis-ci.org/ApptuitAI/prometheus-exporters)
+# MySQL Server Metrics Exporter [![Build Status](https://travis-ci.com/ApptuitAI/prometheus-exporters.svg?branch=master)](https://travis-ci.com/ApptuitAI/prometheus-exporters)
 
 Prometheus exporter for MySQL Server metrics for reporting metrics to Apptuit.ai
 

--- a/node_exporter/README.md
+++ b/node_exporter/README.md
@@ -1,4 +1,4 @@
-# Node Metrics Exporter [![Build Status](https://www.travis-ci.org/ApptuitAI/prometheus-exporters.svg?branch=master)](https://www.travis-ci.org/ApptuitAI/prometheus-exporters)
+# Node Metrics Exporter [![Build Status](https://travis-ci.com/ApptuitAI/prometheus-exporters.svg?branch=master)](https://travis-ci.com/ApptuitAI/prometheus-exporters)
 
 Prometheus Node metrics exporter for reporting metrics to Apptuit.ai
 


### PR DESCRIPTION
* Fix stop issues with JMX class of exporters - make stop option kill all child process tree.
* Update main repo README with cassandra, redis and postgresql links.
* Fix pid file directories not being created for exporters for non-systemd OS versions.
* Log times when start/stop was called into logs
* Fix the extra curly brace for default URL sop in memcached/install.sh

https://github.com/ApptuitAI/prometheus-exporters/issues/7